### PR TITLE
Fix some typos 

### DIFF
--- a/2022-07-08-mvq.md
+++ b/2022-07-08-mvq.md
@@ -218,22 +218,22 @@ x_approx = chosen_codebooks.sum(dim=0)
 
 
 下面解析中假设 num_codebooks=8, 即一个 float embedding 被量化为 8 个整数。
-首先根据 encoder 中的 linear + argmax 可以获得一组 codebook_index，包含8个属于[0, 255]的整数，不妨记作 ${cd\_init}$, 它必然是上面提到的 ${Total}$ 个组合之一。假设其对应的重构误差为 ${RRL\_init}$，现在需要思考一个问题，${cd\_init}$ 是 ${Total}$ 中这么多组合中重构误差最小的那么个吗？或者说有没有如何找到一组 codebook_index，让它的重构误差比 ${cd\_init}$ 还要来的小？
+首先根据 encoder 中的 linear + argmax 可以获得一组 codebook_index，包含8个属于[0, 255]的整数，不妨记作 ${cd_{init}}$, 它必然是上面提到的 ${Total}$ 个组合之一。假设其对应的重构误差为 ${RRL_{init}}$，现在需要思考一个问题，${cd_{init}}$ 是 ${Total}$ 中这么多组合中重构误差最小的那么个吗？或者说有没有如何找到一组 codebook_index，让它的重构误差比 ${cd_{init}}$ 还要来的小？
 
-针对这个问题，先探究一个特别粗糙的方案，记为**草量级版本**。 假设 ${cd\_init = [i_1, i_2, i_3, i_4, i_5, i_6, i_7, i_8]}$ ; 其中 ${i_k}$ 是一个属于[0, 255]的整数。 假设暂时不动${[i_2,..., i_7, i_8]}$ 这 **7** 个数, 我们把 ${i_1}$ 位置上的其余256种可能性都尝试一遍，不妨记这些所有的可能性为 ${cd\_all_256}$,它们对应的重构误差记为 ${RRL\_all\_256}$； 然后对 ${RRL\_all\_256}$ 进行排序，取最小值对应的组合作为优化后的量化结果,记为 ${cd\_refined}$，对应的重构误差为 ${RRL\_refined}$, 很明显 ${RRL\_refined <= RRL\_init}$。
+针对这个问题，先探究一个特别粗糙的方案，记为**草量级版本**。 假设 ${cd_{init} = [i_1, i_2, i_3, i_4, i_5, i_6, i_7, i_8]}$ ; 其中 ${i_k}$ 是一个属于[0, 255]的整数。 假设暂时不动${[i_2,..., i_7, i_8]}$ 这 **7** 个数, 我们把 ${i_1}$ 位置上的其余256种可能性都尝试一遍，不妨记这些所有的可能性为 ${cd_{all\_256}}$,它们对应的重构误差记为 ${RRL_{all\_256}}$； 然后对 ${RRL_{all\_256}}$ 进行排序，取最小值对应的组合作为优化后的量化结果,记为 ${cd_{refined}}$，对应的重构误差为 ${RRL_{refined}}$, 很明显 ${RRL_{refined} <= RRL_{init}}$。
 
-**函数 \_refine_index** 充分发挥上述**定余求一**的思想,在 ${cd\_init}$ 的基础上，通过多轮迭代优化，最终获得RRL更低的 ${cd\_refined}$。 
+**函数 \_refine_index** 充分发挥上述**定余求一**的思想,在 ${cd_{init}}$ 的基础上，通过多轮迭代优化，最终获得RRL更低的 ${cd_{refined}}$。 
 
 该函数中有三个关键的变量N， K， L, 下图**自下而上**列出迭代搜索过程中，N-K-L三个数值的变化；
 
 
 
-上图每一层代表一轮搜索的过程。其中**第一层**，可以看做是前述**草量级版本**的 **并行化**，记为**轻量级**版本。其思想在于对于 ${N=8}$ 个位点中的每个 ${i\_k}$, 穷举其所有的 ${K=256}$ 种可能性，并结合另外7个来自于 ${cd\_init}$ 的 ${i\_others}$ 计算RRL; 对于每个位点，根据RRL的大小对 ${K}$ 个候选进行排序，选其中最优的 ${K\_\text{cutoff}}$ 个进入下一轮迭代。此处对应[Dan哥注释](https://github.com/k2-fsa/multi_quantization/blob/446920cabcb384d20132c5dd7d97cb5ec8e27aa8/multi_quantization/quantization.py#L348 "K_cutoff注释"):
+上图每一层代表一轮搜索的过程。其中**第一层**，可以看做是前述**草量级版本**的 **并行化**，记为**轻量级**版本。其思想在于对于 ${N=8}$ 个位点中的每个 ${i_k}$, 穷举其所有的 ${K=256}$ 种可能性，并结合另外7个来自于 ${cd_{init}}$ 的 ${i_{others}}$ 计算RRL; 对于每个位点，根据RRL的大小对 ${K}$ 个候选进行排序，选其中最优的 ${K_\text{cutoff}}$ 个进入下一轮迭代。此处对应[Dan哥注释](https://github.com/k2-fsa/multi_quantization/blob/446920cabcb384d20132c5dd7d97cb5ec8e27aa8/multi_quantization/quantization.py#L348 "K_cutoff注释"):
 ```
 reduce K to K_cutoff by sorting and taking the K_cutoff best possibilities for each choice.
 ```
 
-值得注意的是，每个位点是并行处理的。每个位点在确定自己的最优个 ${K\_\text{cutoff}}$ 时，并不知道对方的搜索结果。这就面临一个风险，${i\_1}$ 位置上的最优个 ${K\_\text{cutoff}}$ 个候选是和其余7个来自 ${c\_init}$ 中的 index 一起计算 RRL，但是这7个数在它们对应位置的筛选过程中**可能**被**淘汰掉了**。理论上来说，甚至会出现 ${RRL\_refined > RRL\_init}$ 情况！！！ 
+值得注意的是，每个位点是并行处理的。每个位点在确定自己的最优个 ${K_\text{cutoff}}$ 时，并不知道对方的搜索结果。这就面临一个风险，${i_1}$ 位置上的最优个 ${K_\text{cutoff}}$ 个候选是和其余7个来自 ${c_{init}}$ 中的 index 一起计算 RRL，但是这7个数在它们对应位置的筛选过程中**可能**被**淘汰掉了**。理论上来说，甚至会出现 ${RRL_{refined} > RRL_{init}}$ 情况！！！ 
 
 现在给出一个简单的示例解释这种情况的可能性。假设 dim=1, num_codebooks=2;即我们要把一个float **量化**为两个整数，每个整数的分布范围是[0, 4]，self.centers 包含的参数维度[num_codebooks, codebook_size, dim] = [2, 5, 1],其值为：
 ```
@@ -244,13 +244,13 @@ reduce K to K_cutoff by sorting and taking the K_cutoff best possibilities for e
 ]
 ```
 
-根据以上假设条件， 如果待量化的输入 ${x=0.52}$， encoder 通过 linear + argmax 得到的 ${cd\_init = [2, 2]}$； 
+根据以上假设条件， 如果待量化的输入 ${x=0.52}$， encoder 通过 linear + argmax 得到的 ${cd_{init} = [2, 2]}$； 
 此时得到的重构结果为 $\hat{x} = 0.3 + 0.3 = 0.6$。
-采用上述**并行化的轻量级算法**, 假设 ${K\_\text{cutoff} = 1}$, 对于位点 ${i_1}$, 由于 ${i_2 = 2}$，遍历 ${i_1}$ 的5种全部候选值，显然最佳结果为 ${i_1 = 1}$, 即操作 ${i_1}$ 位置的这部分算法**认为**它修改后的重构结果应该是 $\hat{x} = 0.2 + 0.3 = 0.5$； 
+采用上述**并行化的轻量级算法**, 假设 ${K_\text{cutoff} = 1}$, 对于位点 ${i_1}$, 由于 ${i_2 = 2}$，遍历 ${i_1}$ 的5种全部候选值，显然最佳结果为 ${i_1 = 1}$, 即操作 ${i_1}$ 位置的这部分算法**认为**它修改后的重构结果应该是 $\hat{x} = 0.2 + 0.3 = 0.5$； 
 
-但是此刻还有一个并行的算法在操作位点 ${i_2}$，在位点${i_1}$做出决定时，它在${cd\_init}$中的${i_1 = 2}$的基础上做出了 ${i_2 = 1}$的选择, 即它**认为**它修改后的的重构结果应该为  $\hat{x} = 0.3 + 0.2 = 0.5$;  
+但是此刻还有一个并行的算法在操作位点 ${i_2}$，在位点${i_1}$做出决定时，它在${cd_{init}}$中的${i_1 = 2}$的基础上做出了 ${i_2 = 1}$的选择, 即它**认为**它修改后的的重构结果应该为  $\hat{x} = 0.3 + 0.2 = 0.5$;  
 
-由于K_cutoff = 1, 它们都返回了一个最佳候选，两路并行程序给出的结果汇总后， 得到 ${cd\_refine = [1, 1]}$ ，即 $\hat{x} = 0.2 + 0.2 = 0.4$.
+由于$K_{cutoff} = 1$, 它们都返回了一个最佳候选，两路并行程序给出的结果汇总后， 得到 ${cd_{refine} = [1, 1]}$ ，即 $\hat{x} = 0.2 + 0.2 = 0.4$.
 
 综上，本来重构结果与目标距离${-0.08 = 0.52 - 0.6}$, 一番操作猛如虎之后，与目标距离成了 ${0.12 = 0.52 - 0.4}$，反倒还增大了50%。 
 
@@ -262,7 +262,7 @@ not not increase the sum-squared loss, but works OK in practice.
 
 行文至此，不禁想起欧亨利的《麦琪的礼物》，相爱的小夫妻都从对方的角度考虑，忍痛割爱，然而最终还不如什么都不做。好像也不对，虽然忍痛换来的礼物是完全用不上的摆设，但是他们收获了真挚的爱情。（苍天啊，为什么辛辛苦苦地在这研究算法还要被喂狗粮，我呸！）
 
-正如生活中很难遇到小说中的情节，在实际训练过程中，函数 [\_refine_indexes] 一般也不会遇到上面给出的极端反例，一般情况下，${RRL\_refined} <= {RRL\_init}$， 如下所示为[连续5次使用函数](https://github.com/k2-fsa/multi_quantization/blob/ecea30b79699e2e6f24d253f2563f78e4c1441fc/multi_quantization/quantization.py#L302 "默认连续5次调用_refine_indexes函数") ${\_refine\_indexes}$ 重构误差RRL的变化：
+正如生活中很难遇到小说中的情节，在实际训练过程中，函数 [\_refine_indexes] 一般也不会遇到上面给出的极端反例，一般情况下，${RRL_{refined}} <= {RRL_{init}}$， 如下所示为[连续5次使用函数](https://github.com/k2-fsa/multi_quantization/blob/ecea30b79699e2e6f24d253f2563f78e4c1441fc/multi_quantization/quantization.py#L302 "默认连续5次调用_refine_indexes函数") ${\_refine\_indexes}$ 重构误差RRL的变化：
 
 ```
 loss_per_iter=[0.496, 0.451, 0.439, 0.437, 0.436, 0.435],
@@ -277,18 +277,18 @@ loss_per_iter=[0.482, 0.442, 0.431, 0.429, 0.428, 0.428],
 
 另外引入的 logprob_loss 也可以一定程度上缓解这种情况，详见后文。
 
-言归正传，回归到 num_codebooks=8, K_cutoff=16 的设定，采用上述**轻量级**算法的搜索之后，${[i_1, i_2, ..., i_8]}$ 每个位置都从256个候选中挑出了 k_cutoff=16 个候选，他们的排列组合共有 ${16^8 = 4,294,967,296}$ 个，确实比最开始的1800亿亿个小了很多，但是依然很大，而且后续怎么处理？要穷举这个40亿个潜在结果吗？
+言归正传，回归到 num_codebooks=8, $K_{cutoff}=16$ 的设定，采用上述**轻量级**算法的搜索之后，${[i_1, i_2, ..., i_8]}$ 每个位置都从256个候选中挑出了 k_cutoff=16 个候选，他们的排列组合共有 ${16^8 = 4,294,967,296}$ 个，确实比最开始的1800亿亿个小了很多，但是依然很大，而且后续怎么处理？要穷举这个40亿个潜在结果吗？
 
 针对上述问题，multi_quantization 项目在**轻量级**算法的基础上新增加一个 [Combine pairs of choices](https://github.com/k2-fsa/multi_quantization/blob/446920cabcb384d20132c5dd7d97cb5ec8e27aa8/multi_quantization/quantization.py#L505 "combine pairs of choices") 的机制。将引入该机制后的算法记为**重量级**算法。
 
-假设 ${[i_1, i_2, ..., i_8]}$ 每个位点已选出的 ${K\_\text{cutoff}}$ 个候选，**combine** 机制将**相邻**两个位点分为一组，得到 $\frac{N}{2}$，穷举每组内部的两个位点的所有组合，共 ${K\_\text{cutoff}}$ * ${K\_\text{cutoff}}$ 个；结合**定余求一**的思想，结合 ${c\_init}$ 中其它位点的值，计算这 ${K\_\text{cutoff}}$ * ${K\_\text{cutoff}}$ 个组合对应的 RRL, 并根据RRL 取较小的 ${K\_\text{cutoff}}$ 个进入下一轮排序。由于此时计算 RRL,参与排序的是两个相邻位点的组合，所以在后续的迭代过程中，这两个位点要一直捆绑在一起，即此时 L = 2。依此类推，在下一轮次的**相邻**组 combine 后， L 会进一步翻倍为 L = 4。上述解析[对应Dan哥代码注释](https://github.com/k2-fsa/multi_quantization/blob/446920cabcb384d20132c5dd7d97cb5ec8e27aa8/multi_quantization/quantization.py#L347 "N/K/L的变化")：
+假设 ${[i_1, i_2, ..., i_8]}$ 每个位点已选出的 ${K_\text{cutoff}}$ 个候选，**combine** 机制将**相邻**两个位点分为一组，得到 $\frac{N}{2}$，穷举每组内部的两个位点的所有组合，共 ${K_\text{cutoff}}$ * ${K_\text{cutoff}}$ 个；结合**定余求一**的思想，结合 ${c_{init}}$ 中其它位点的值，计算这 ${K_\text{cutoff}}$ * ${K_\text{cutoff}}$ 个组合对应的 RRL, 并根据RRL 取较小的 ${K_\text{cutoff}}$ 个进入下一轮排序。由于此时计算 RRL,参与排序的是两个相邻位点的组合，所以在后续的迭代过程中，这两个位点要一直捆绑在一起，即此时 L = 2。依此类推，在下一轮次的**相邻**组 combine 后， L 会进一步翻倍为 L = 4。上述解析[对应Dan哥代码注释](https://github.com/k2-fsa/multi_quantization/blob/446920cabcb384d20132c5dd7d97cb5ec8e27aa8/multi_quantization/quantization.py#L347 "N/K/L的变化")：
 ```
 combine pairs of choices, so that N := N//2, K := K ** 2, L *= 2
 ```
-采用这种相邻配对分组计算，**定余求一**的方法，不需要穷举上文提到的40亿种组合，仅需计算 ${K\_\text{cutoff} * K\_\text{cutoff} * \frac{N}{2} = 16 * 16 * 4 = 1024}$ 种组合，而且它们还可以并行计算，极大地提高了搜索效率。 
+采用这种相邻配对分组计算，**定余求一**的方法，不需要穷举上文提到的40亿种组合，仅需计算 ${K_\text{cutoff} * K_\text{cutoff} * \frac{N}{2} = 16 * 16 * 4 = 1024}$ 种组合，而且它们还可以并行计算，极大地提高了搜索效率。 
 
 
-回顾一下上面迭代 refine 的示意图，每一层都代表一次**相邻组**配对，基于**定余求一**的基本思想，对于每个配对的组合选出 ${K\_\text{cutoff}}$ 个**最有**候选。每次迭代后，单个组合的元素个数L都会扩大一倍，最终 L = num_codebooks, 此时最小值 RRL 对应的组合即为需要求解的 ${cd\_refined}$。
+回顾一下上面迭代 refine 的示意图，每一层都代表一次**相邻组**配对，基于**定余求一**的基本思想，对于每个配对的组合选出 ${K_\text{cutoff}}$ 个**最优**候选。每次迭代后，单个组合的元素个数L都会扩大一倍，最终 L = num_codebooks, 此时最小值 RRL 对应的组合即为需要求解的 ${cd_{refined}}$。
 
 该算法解析即将进入尾声，最后介绍代码中穷举**相邻组**两两配对的 trick,[代码如下](https://github.com/k2-fsa/multi_quantization/blob/446920cabcb384d20132c5dd7d97cb5ec8e27aa8/multi_quantization/quantization.py#L517 "两两配对")：
 ```
@@ -326,7 +326,7 @@ tensor([[1, 2],
 
 #### 4.3.3 logprob_loss 的作用
 
-在上文 ${cd\_refined}$ 迭代搜索过程中，一个很重要思想就是**定余求一**，也就是说我们在搜索某一个位点上的较佳候选时，其余的位点是直接用了用 quantizer.to_logits 对应的 (linear + argmax)  计算出来的 ${cd\_init}$ 的值。万一这个初始值 ${cd\_init}$ 很坑怎么办？ 在上文中，我们也给出来一个案例，一通操作之后，重构出来的结果误差还更大了。在 **multi_quantizaiton** 库中，Dan哥给出的优化方案让 quantizer.to_logits 模块去学习 refine 之后的结果，这样 （linear + argmax）给出的 ${cd\_init}$ 就会不断向 ${cd\_refined}$ 组合逼近。对应的[代码为](https://github.com/k2-fsa/multi_quantization/blob/446920cabcb384d20132c5dd7d97cb5ec8e27aa8/multi_quantization/quantization.py#L218 "logprob_loss 代码")
+在上文 ${cd_{refined}}$ 迭代搜索过程中，一个很重要思想就是**定余求一**，也就是说我们在搜索某一个位点上的较佳候选时，其余的位点是直接用了用 quantizer.to_logits 对应的 (linear + argmax)  计算出来的 ${cd_{init}}$ 的值。万一这个初始值 ${cd_{init}}$ 很坑怎么办？ 在上文中，我们也给出来一个案例，一通操作之后，重构出来的结果误差还更大了。在 **multi_quantizaiton** 库中，Dan哥给出的优化方案让 quantizer.to_logits 模块去学习 refine 之后的结果，这样 （linear + argmax）给出的 ${cd_{init}}$ 就会不断向 ${cd_{refined}}$ 组合逼近。对应的[代码为](https://github.com/k2-fsa/multi_quantization/blob/446920cabcb384d20132c5dd7d97cb5ec8e27aa8/multi_quantization/quantization.py#L218 "logprob_loss 代码")
 ```
         # Get logprob loss and class-entropy loss
         # wasteful.. already computed logits..
@@ -337,7 +337,7 @@ tensor([[1, 2],
                                      index=indexes.unsqueeze(2))
         logprob_loss = -chosen_logits.mean()
 ```
-如Dan哥在注释中所说，本质上这就是个交叉墒损失函数（Cross-Entropy loss, CE）。从 CE 的角度看，相当于以 ${cd\_refined}$ 为 label, 去训练 quantizer.to_logits 模块，从而促使 ${cd\_init}$ 逐渐接近 ${cd\_refined}$。
+如Dan哥在注释中所说，本质上这就是个交叉墒损失函数（Cross-Entropy loss, CE）。从 CE 的角度看，相当于以 ${cd_{refined}}$ 为 label, 去训练 quantizer.to_logits 模块，从而促使 ${cd_{init}}$ 逐渐接近 ${cd_{refined}}$。
 
 至此，我们浅析了 quantizer 背后的一些关键思想，然而Dan哥的设计前后呼应，非常巧妙；上述解析必然有疏漏之处，读者海涵。
 

--- a/2022-10-14-sherpa-ncnn.md
+++ b/2022-10-14-sherpa-ncnn.md
@@ -351,11 +351,9 @@ build-aarch64-linux-gnu/bin/sherpa-ncnn: ELF 64-bit LSB executable, ARM aarch64,
 
 编译好 ``sherpa-ncnn`` 之后，我们就可以用转换过的模型进行语音识别了。
 
-> 注：目前 ``sherpa-ncnn`` 只实现了 ``greedy search`` 解码方法，不带
-> 任何形式的外部语言模型。
+> 注：目前 ``sherpa-ncnn`` 只实现了 ``greedy search`` 解码方法，不带任何形式的外部语言模型。
 
-为了方便大家测试，我们针对英语和中文，分别提供了转换后的模型。模型下载
-方法如下：
+为了方便大家测试，我们针对英语和中文，分别提供了转换后的模型。模型下载方法如下：
 
 - 下载英文模型
 


### PR DESCRIPTION
Try to fix some typos or equation display error caused by Github. 
Note! There are still many display errors. Though most of the display are right on local vscode preview. 
Fix some subscript error， e.g. $cd_init$ -> $cd_{init}$
Try to avoid Escape Character and blank in the equation expression, this may cause display error. e.g. $ a+b $ to $a+b$
